### PR TITLE
fix: Fixed file name issue while saving when intent type is `CATEGORY_OPENABLE`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,63 @@
-# Miscellaneous
-*.class
-*.log
-*.pyc
-*.swp
-.DS_Store
-.atom/
-.buildlog/
-.history
-.svn/
-migrate_working_dir/
+# https://www.dartlang.org/guides/libraries/private-files
 
-# IntelliJ related
-*.iml
-*.ipr
-*.iws
-.idea/
-
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
-#.vscode/
-
-# Flutter/Dart/Pub related
-# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
-/pubspec.lock
-**/doc/api/
+# Files and directories created by pub
 .dart_tool/
 .packages
+.pub/
 build/
+pubspec.lock
+
+# Directory created by dartdoc
+/doc/api/
+
+# IDE
+*.iml         // IntelliJ
+*.ipr         // IntelliJ
+*.iws         // IntelliJ
+.idea/        // IntelliJ
+.DS_Store     // Mac
+
+# copied from https://github.com/flutter/plugins/blob/master/.gitignore
+.DS_Store
+.atom/
+.idea/
+.vscode/
+
+.packages
+.pub/
+.dart_tool/
+pubspec.lock
+flutter_export_environment.sh
+
+examples/all_plugins/pubspec.yaml
+
+Podfile
+Podfile.lock
+Pods/
+.symlinks/
+**/Flutter/App.framework/
+**/Flutter/Flutter.framework/
+**/Flutter/Generated.xcconfig
+**/Flutter/flutter_assets/
+ServiceDefinitions.json
+xcuserdata/
+**/DerivedData/
+
+local.properties
+keystore.properties
+.gradle/
+gradlew
+gradlew.bat
+gradle-wrapper.jar
+.flutter-plugins-dependencies
+*.iml
+
+GeneratedPluginRegistrant.h
+GeneratedPluginRegistrant.m
+GeneratedPluginRegistrant.java
+build/
+.flutter-plugins
+
+.project
+.classpath
+.settings

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.cleveroad.cr_file_saver'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.cleveroad.cr_file_saver'
+    }
     compileSdkVersion 33
 
     compileOptions {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/src/main/kotlin/com/cleveroad/cr_file_saver/CrFileSaverPlugin.kt
+++ b/android/src/main/kotlin/com/cleveroad/cr_file_saver/CrFileSaverPlugin.kt
@@ -1,15 +1,20 @@
 package com.cleveroad.cr_file_saver
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.provider.MediaStore
+
 import android.util.Log
 import androidx.annotation.NonNull
 import androidx.core.app.ActivityCompat
 import com.cleveroad.cr_file_saver.base.AbstractActivityAware
 import com.cleveroad.cr_file_saver.base.FileSaverPluginCallback
 import com.cleveroad.cr_file_saver.utils.getFileName
+import com.cleveroad.cr_file_saver.utils.getFileNameWithoutExtension
+import com.cleveroad.cr_file_saver.utils.getMimeType
 import com.cleveroad.cr_file_saver.utils.saveFileInBackground
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -19,6 +24,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 import java.io.File
+import kotlin.math.log
 
 /** CrFileSaverPlugin */
 class CrFileSaverPlugin : FlutterPlugin, MethodCallHandler, AbstractActivityAware(),
@@ -82,14 +88,18 @@ class CrFileSaverPlugin : FlutterPlugin, MethodCallHandler, AbstractActivityAwar
     }
 
     override fun onSaveFileDialog(
-        sourceFile: File,
-        result: Pigeon.Result<String>?,
-        destinationFileName: String?
+            context: Context,
+            sourceFile: File,
+            result: Pigeon.Result<String>?,
+            destinationFileName: String?
     ) {
+        val mimeType = getMimeType(context, sourceFile.path);
+        val fileNameWithoutExtension = destinationFileName?.let { getFileNameWithoutExtension(it) } ?: getFileNameWithoutExtension(getFileName(sourceFile.path));
         Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
-            putExtra(Intent.EXTRA_TITLE, destinationFileName ?: getFileName(sourceFile.path))
-            type = "*/*"
+            putExtra(Intent.EXTRA_TITLE, fileNameWithoutExtension)
+            putExtra(MediaStore.MediaColumns.MIME_TYPE, mimeType)
+            type = mimeType
         }.let {
             this.sourceFile = sourceFile
             this.saveFilePendingResult = result

--- a/android/src/main/kotlin/com/cleveroad/cr_file_saver/FileSaverImpl.kt
+++ b/android/src/main/kotlin/com/cleveroad/cr_file_saver/FileSaverImpl.kt
@@ -66,7 +66,7 @@ class FileSaverImpl(private val context: Context, private val callback: FileSave
         result: Pigeon.Result<String>?
     ) {
         val sourceFile = File(params.sourceFilePath)
-        callback.onSaveFileDialog(sourceFile, result, params.destinationFileName)
+        callback.onSaveFileDialog(context, sourceFile, result, params.destinationFileName)
     }
 
     @Suppress("DEPRECATION")

--- a/android/src/main/kotlin/com/cleveroad/cr_file_saver/base/FileSaverPluginCallback.kt
+++ b/android/src/main/kotlin/com/cleveroad/cr_file_saver/base/FileSaverPluginCallback.kt
@@ -1,11 +1,13 @@
 package com.cleveroad.cr_file_saver.base
 
+import android.content.Context
 import com.cleveroad.cr_file_saver.Pigeon
 import java.io.File
 
 interface FileSaverPluginCallback {
     fun onRequestPermission(result: Pigeon.Result<Boolean>?)
     fun onSaveFileDialog(
+        context: Context,
         sourceFile: File,
         result: Pigeon.Result<String>?,
         destinationFileName: String?

--- a/android/src/main/kotlin/com/cleveroad/cr_file_saver/utils/File.kt
+++ b/android/src/main/kotlin/com/cleveroad/cr_file_saver/utils/File.kt
@@ -20,6 +20,14 @@ fun getFileName(url: String): String {
     val last = segments.last();
     return last
 }
+// get file name without extension
+fun getFileNameWithoutExtension(fileName: String): String {
+    val lastIndex = fileName.lastIndexOf('.')
+    if (lastIndex != -1) {
+        return fileName.substring(0, lastIndex)
+    }
+    return fileName
+}
 
 // Only used in old APIs
 @Suppress("DEPRECATION")


### PR DESCRIPTION
- when the file is already present with the provided file name and the user doesn't change the new file name then the saved file is not properly executable due to an incorrect file name
- More Information can be found [here](https://github.com/revanced/revanced-manager/pull/837)
- Added support of AGP 8